### PR TITLE
fix: 🐛 remove hardcoded JAVA_HOME path from Android build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,6 @@ jobs:
           cd android
           ./gradlew bundleRelease assembleRelease -Pandroid.injected.signing.store.file=$RELEASE_STORE_FILE -Pandroid.injected.signing.store.password=$RELEASE_STORE_PASSWORD -Pandroid.injected.signing.key.alias=$RELEASE_KEY_ALIAS -Pandroid.injected.signing.key.password=$RELEASE_KEY_PASSWORD
         env:
-          JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/17.0.13-11/x64
           RELEASE_STORE_FILE: ${{ env.RELEASE_STORE_FILE }}
           RELEASE_STORE_PASSWORD: ${{ env.RELEASE_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ env.RELEASE_KEY_ALIAS }}


### PR DESCRIPTION
## Summary by Sourcery

Remove the hardcoded JAVA_HOME path from the Android build step in the GitHub Actions CI to use the default Java installation.

Bug Fixes:
- Remove hardcoded JAVA_HOME environment variable from the Android build job

CI:
- Omit explicit JAVA_HOME setting in the CI workflow for Android builds